### PR TITLE
Rename public config store property

### DIFF
--- a/packages/bzx-widget-provider-augur/src/BZXWidgetProviderAugur.js
+++ b/packages/bzx-widget-provider-augur/src/BZXWidgetProviderAugur.js
@@ -41,7 +41,8 @@ export default class BZXWidgetProviderAugur {
     const alreadyInjected = typeof web3 !== `undefined`;
     if (alreadyInjected) {
       this.web3 = new Web3(web3.currentProvider);
-      this.web3.currentProvider.publicConfigStore.on("update", result =>
+      const publicConfigKey = web3.currentProvider.isMetaMask ? '_publicConfigStore' : 'publicConfigStore';
+      this.web3.currentProvider[publicConfigKey].on("update", result =>
         this.eventEmitter.emit(EVENT_ACCOUNT_UPDATE, result ? result.selectedAddress : "")
       );
       this.web3.currentProvider.enable().then(


### PR DESCRIPTION
- Renames `publicConfigStore` to `_publicConfigStore` if the provider is MetaMask

For details, see: https://github.com/bZxNetwork/fulcrum_ui/pull/179

Note that MetaMask is removing the public config store entirely in an upcoming update, and you should migrate to using [the corresponding events](https://docs.metamask.io/guide/ethereum-provider.html#events).